### PR TITLE
Models not being removed from HasOne relationships

### DIFF
--- a/backbone.JJRelational.coffee
+++ b/backbone.JJRelational.coffee
@@ -715,8 +715,8 @@ do () ->
 			prev = @.get relation.key
 			@.attributes[relation.key] = val
 
-			if silentRelation then return
 			if prev instanceof relation.relatedModel is true then prev.removeFromRelation relation.reverseKey, @, true
+			if silentRelation then return
 			if val instanceof relation.relatedModel is true
 				# pass on relation
 				val.addToRelation @, relation.reverseKey, true

--- a/backbone.JJRelational.js
+++ b/backbone.JJRelational.js
@@ -813,11 +813,11 @@
       }
       prev = this.get(relation.key);
       this.attributes[relation.key] = val;
-      if (silentRelation) {
-        return;
-      }
       if (prev instanceof relation.relatedModel === true) {
         prev.removeFromRelation(relation.reverseKey, this, true);
+      }
+      if (silentRelation) {
+        return;
       }
       if (val instanceof relation.relatedModel === true) {
         val.addToRelation(this, relation.reverseKey, true);

--- a/tests/public/backbone.JJRelational.coffee
+++ b/tests/public/backbone.JJRelational.coffee
@@ -715,8 +715,8 @@ do () ->
 			prev = @.get relation.key
 			@.attributes[relation.key] = val
 
-			if silentRelation then return
 			if prev instanceof relation.relatedModel is true then prev.removeFromRelation relation.reverseKey, @, true
+			if silentRelation then return
 			if val instanceof relation.relatedModel is true
 				# pass on relation
 				val.addToRelation @, relation.reverseKey, true

--- a/tests/public/backbone.JJRelational.js
+++ b/tests/public/backbone.JJRelational.js
@@ -813,11 +813,11 @@
       }
       prev = this.get(relation.key);
       this.attributes[relation.key] = val;
-      if (silentRelation) {
-        return;
-      }
       if (prev instanceof relation.relatedModel === true) {
         prev.removeFromRelation(relation.reverseKey, this, true);
+      }
+      if (silentRelation) {
+        return;
       }
       if (val instanceof relation.relatedModel === true) {
         val.addToRelation(this, relation.reverseKey, true);

--- a/tests/public/test.coffee
+++ b/tests/public/test.coffee
@@ -150,8 +150,22 @@ describe 'New author', ->
 describe 'Testing setting/adding/removing from relations', ->
 	orwell = new Author {name: 'George Orwell' }
 	describe 'HasOne Relation', ->
+
 		eileen = new Literature.Wife { name: 'Eileen' }
 		orwell.set { wife: eileen }
+
+    it 'When an Author adds a Book to its `books` list, the Book should be removed from all other Authors `books` list', ->
+      author1 = new Author(name: 'Author1')
+      author2 = new Author(name: 'Author2')
+      book1 = new Book(name: 'Book1')
+
+      author1.get('books').add book1
+      author1.get('books').contains(book1).should.equal true
+      author2.get('books').contains(book1).should.equal false
+
+      author2.get('books').add book1
+      author1.get('books').contains(book1).should.equal false
+      author2.get('books').contains(book1).should.equal true
 
 		it 'Adding Eileen to Orwell: Eileen should have George Orwell as husband', ->
 			eileen.get('husband').get('name').should.equal 'George Orwell'

--- a/tests/public/test.js
+++ b/tests/public/test.js
@@ -176,6 +176,24 @@ describe('Testing setting/adding/removing from relations', function() {
     orwell.set({
       wife: eileen
     });
+    it('When an Author adds a Book to its `books` list, the Book should be removed from all other Authors `books` list', function() {
+      var author1, author2, book1;
+      author1 = new Author({
+        name: 'Author1'
+      });
+      author2 = new Author({
+        name: 'Author2'
+      });
+      book1 = new Book({
+        name: 'Book1'
+      });
+      author1.get('books').add(book1);
+      author1.get('books').contains(book1).should.equal(true);
+      author2.get('books').contains(book1).should.equal(false);
+      author2.get('books').add(book1);
+      author1.get('books').contains(book1).should.equal(false);
+      return author2.get('books').contains(book1).should.equal(true);
+    });
     it('Adding Eileen to Orwell: Eileen should have George Orwell as husband', function() {
       return eileen.get('husband').get('name').should.equal('George Orwell');
     });


### PR DESCRIPTION
Duplicated from: https://github.com/jj-studio/Backbone-JJRelational/pull/8

When a model A adds a related model B to its collection, if B has_one A, then all other model A's should automatically remove that model B from their collections.

Example:
If the `Book` model has a `has_one` relationship to the `Author` model, then...
````
author1.get('books').add(book1);
author2.get('books').add(book1);
````
`author1.get('books')` should no longer contain `book1`

This pull request fixes that, with a supplied unit test.