### PR TITLE
Collection#fetch re-parses models

### DIFF
--- a/backbone.JJRelational.coffee
+++ b/backbone.JJRelational.coffee
@@ -1149,7 +1149,7 @@ do () ->
 				if existingModel
 					# this model exists. add it to existingModels[] and simply update the attributes as in 'fetch'
 					existingModel.set respObj, options
-					existingModels.push existingModel
+					existingModels.push existingModel.pick(_.keys(respObj).concat(existingModel.idAttribute))
 					args.push respObj
 			parsedResp = _.without.apply that, args
 

--- a/backbone.JJRelational.js
+++ b/backbone.JJRelational.js
@@ -1339,7 +1339,7 @@
         existingModel = Backbone.JJStore._byId(storeIdentifier, id);
         if (existingModel) {
           existingModel.set(respObj, options);
-          existingModels.push(existingModel);
+          existingModels.push(existingModel.pick(_.keys(respObj).concat(existingModel.idAttribute)));
           args.push(respObj);
         }
       }

--- a/tests/public/backbone.JJRelational.coffee
+++ b/tests/public/backbone.JJRelational.coffee
@@ -1149,7 +1149,7 @@ do () ->
 				if existingModel
 					# this model exists. add it to existingModels[] and simply update the attributes as in 'fetch'
 					existingModel.set respObj, options
-					existingModels.push existingModel
+					existingModels.push existingModel.pick(_.keys(respObj).concat(existingModel.idAttribute))
 					args.push respObj
 			parsedResp = _.without.apply that, args
 

--- a/tests/public/backbone.JJRelational.js
+++ b/tests/public/backbone.JJRelational.js
@@ -1339,7 +1339,7 @@
         existingModel = Backbone.JJStore._byId(storeIdentifier, id);
         if (existingModel) {
           existingModel.set(respObj, options);
-          existingModels.push(existingModel);
+          existingModels.push(existingModel.pick(_.keys(respObj).concat(existingModel.idAttribute)));
           args.push(respObj);
         }
       }


### PR DESCRIPTION
When calling Collection.fetch, any existing models will be passed along at the end when collection will internally call `set` (or `reset`). Vanilla Backbone behavior would be to pass `set` or `reset` a raw response object, not an actual model, because the collection is going to run `parse` on it since the call was initiated from `fetch`.

If we pass entire models, it means that any `parse` function the user may have written will actually be being passed a Backbone.Model object, instead of the "raw" response object.

This PR simply calls `existingModel.pick(_.keys(responseObject))` in order to pass `set` or `reset` a list of attributes from the model, rather than the actual model itself.

I'm not familiar with this codebase enough to know if that was done intentionally/for good reason, or if it was just a minor oversight. It doesn't break any tests, and I'm using it in my application and everything seems to be working fine.

Let me know your thoughts.