### PR TITLE
add a 'relationsInstalled' event on the model

### DIFF
--- a/backbone.JJRelational.coffee
+++ b/backbone.JJRelational.coffee
@@ -208,6 +208,7 @@ do () ->
 			@.__populate_rels_with_atts(attributes, options)
 			# trigger the creation
 			Backbone.JJStore.Events.trigger 'created:' + @.storeIdentifier, @
+      @.trigger('relationsInstalled')
 			@
 
 		###*

--- a/backbone.JJRelational.js
+++ b/backbone.JJRelational.js
@@ -208,6 +208,7 @@
       Backbone.JJStore.__registerModelInStore(this);
       this.__populate_rels_with_atts(attributes, options);
       Backbone.JJStore.Events.trigger('created:' + this.storeIdentifier, this);
+      this.trigger('relationsInstalled');
       return this;
     },
     /**

--- a/tests/public/backbone.JJRelational.coffee
+++ b/tests/public/backbone.JJRelational.coffee
@@ -208,6 +208,7 @@ do () ->
 			@.__populate_rels_with_atts(attributes, options)
 			# trigger the creation
 			Backbone.JJStore.Events.trigger 'created:' + @.storeIdentifier, @
+      @.trigger('relationsInstalled')
 			@
 
 		###*

--- a/tests/public/backbone.JJRelational.js
+++ b/tests/public/backbone.JJRelational.js
@@ -208,6 +208,7 @@
       Backbone.JJStore.__registerModelInStore(this);
       this.__populate_rels_with_atts(attributes, options);
       Backbone.JJStore.Events.trigger('created:' + this.storeIdentifier, this);
+      this.trigger('relationsInstalled');
       return this;
     },
     /**


### PR DESCRIPTION
Because relations are not set up yet in a Model's `initialize` function, it can be handy to have a hook to know when they are. This PR adds `this.trigger('relationsInstalled')` to the end of `Backbone.JJRelationalModel.constructor` to achieve this.